### PR TITLE
Remove one bug in BatchNorm2d from GoogleNet

### DIFF
--- a/models/googlenet.py
+++ b/models/googlenet.py
@@ -42,7 +42,7 @@ class Inception(nn.Module):
             nn.BatchNorm2d(n5x5_reduce),
             nn.ReLU(inplace=True),
             nn.Conv2d(n5x5_reduce, n5x5, kernel_size=3, padding=1),
-            nn.BatchNorm2d(n5x5, n5x5),
+            nn.BatchNorm2d(n5x5),
             nn.ReLU(inplace=True),
             nn.Conv2d(n5x5, n5x5, kernel_size=3, padding=1),
             nn.BatchNorm2d(n5x5),


### PR DESCRIPTION
This PR remove one redundant parameter in `BatchNorm2d`.
According to https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm2d.html#torch.nn.BatchNorm2d, the second parameter of `torch.nn.BatchNorm2d` corresponds to `eps=1e-05`, where the default value is preferred.